### PR TITLE
🚑 티입 오류 긴급 수정

### DIFF
--- a/src/components/search/types.ts
+++ b/src/components/search/types.ts
@@ -32,8 +32,8 @@ export type SearchUser = {
   display_name: string;
   image_url?: string | null;
   bio?: string | null;
-  isFollowing: boolean; // 내가 이 사람을 팔로우 중인지
-  isMe: boolean; // 나 자신인지 (나 자신이면 버튼 안 보이게)
+  isFollowing?: boolean; // 내가 이 사람을 팔로우 중인지
+  isMe?: boolean; // 나 자신인지 (나 자신이면 버튼 안 보이게)
 };
 
 export type SearchTag = {


### PR DESCRIPTION
## 📖 개요

- 아래 오류 수정!!

` '{ id: string; display_name: string; image_url: string | null; bio: string | null; }' 형식에 'SearchUser' 형식의 isFollowing, isMe 속성이 없습니다.ts(2739)
(property) image_url: string | null
`

## ✅ 관련 이슈

- user.mapper.ts 타입 오류 수정!!

## 🛠️ 상세 작업 내용

- [x] user.mapper.ts 타입 오류 수정!

